### PR TITLE
[D4CRIS-848] The side buttons in the full item view now properly display on the side

### DIFF
--- a/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemTag.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/ItemTag.java
@@ -406,6 +406,8 @@ public class ItemTag extends TagSupport
         HttpServletRequest request = (HttpServletRequest)pageContext.getRequest();
         Context context = UIUtil.obtainContext(request);
         
+        out.println("<div class=\"col-lg-9\">");
+        
         out.println("<table class=\"table itemDisplayTable\">");
 
         for (DisplayMetadata display : DisplayItemMetadataUtils.getDisplayMetadata(context, request, item, style)) {
@@ -443,7 +445,7 @@ public class ItemTag extends TagSupport
         // Get all the metadata
         List<IMetadataValue> values = itemService.getMetadataWithoutPlaceholder(item, Item.ANY, Item.ANY, Item.ANY, Item.ANY);
 
-        out.println("<div class=\"panel panel-info\"><div class=\"panel-heading\">"
+        out.println("<div class=\"panel panel-info col-lg-9\"><div class=\"panel-heading\">"
                 + LocaleSupport.getLocalizedMessage(pageContext,
                         "org.dspace.app.webui.jsptag.ItemTag.full") + "</div>");
 

--- a/dspace-jspui/src/main/webapp/display-item.jsp
+++ b/dspace-jspui/src/main/webapp/display-item.jsp
@@ -331,7 +331,7 @@ j(document).ready(function() {
 %>
 
 <div class="row">
-<div id="wrapperDisplayItem" class="col-lg-9">
+<div id="wrapperDisplayItem" class="col-lg-12">
     <dspace:item-preview item="<%= item %>" />
     <dspace:item item="<%= item %>" collections="<%= collections %>" style="<%= displayStyle %>" />
     <%-- SFX Link --%>


### PR DESCRIPTION
Added the `<div class="col-lg-9">` that was closed in `ItemTag.render()` but
was never opened and resulted in improper formatting,
Added `col-lg-9` to the `<div>` in `ItemTag.renderFull()` to match
`ItemTag.render()`,
Extended the space occupied by the `<div class="row">` that
contains the table and the boxes from 9 to 12 columns.